### PR TITLE
Pin kaminari gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ end
 
 gem 'pg'
 gem 'resque-pool'
+gem 'kaminari', '< 1.0'


### PR DESCRIPTION
Version 1.0.0 of the `kaminari` Gem including the breaking change that support for Rails 4 was dropped.  Hence, we pin `kaminari` to a pre-1.x version.