### PR TITLE
Update rubyzip Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -522,7 +522,7 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     sass (3.4.22)
     sass-rails (5.0.5)
       railties (>= 4.0.0, < 6)


### PR DESCRIPTION
Update "rubyzip" Gem to 1.2.1 due to severe vulnerability in current version.